### PR TITLE
Add support for a string value that calls the command that corresponds to the string

### DIFF
--- a/packages/slate-keymap/__tests__/index.js
+++ b/packages/slate-keymap/__tests__/index.js
@@ -11,6 +11,19 @@ describe("KeyMap", () => {
     expect(enterFn).toHaveBeenCalled();
   });
 
+  it("should call editor.command if the argument is a string", () => {
+    const command = jest.fn();
+    const keyMap = KeyMap({ "shift+enter": "softBreak" });
+
+    keyMap.onKeyDown(
+      events.keyDown({ key: "Enter", shiftKey: true }),
+      { command },
+      jest.fn()
+    );
+
+    expect(command).toHaveBeenCalledWith("softBreak");
+  });
+
   it("should handle modifiers", () => {
     const shiftEnterFn = jest.fn();
     const keyMap = KeyMap({ "shift+enter": shiftEnterFn });

--- a/packages/slate-keymap/docs/index.mdx
+++ b/packages/slate-keymap/docs/index.mdx
@@ -26,7 +26,9 @@ import Keymap from "@convertkit/slate-keymap";
 
 const plugins = [
   Keymap({
-    "mod+a": (event, editor) => editor.selectAll()
+    "mod+a": (event, editor) => editor.selectAll(),
+    // You can also pass a string and it will call the command with that name
+    "shift+enter": "softBreak"
   })
 ];
 ```

--- a/packages/slate-keymap/src/index.js
+++ b/packages/slate-keymap/src/index.js
@@ -11,9 +11,16 @@ const Keymap = (shortcuts, options) => {
 
     const check = (event, editor) => isKeyPressed(event) && config.if(editor);
 
+    const handler =
+      typeof shortcuts[key] == "string"
+        ? (event, editor) => {
+            editor.command(shortcuts[key]);
+          }
+        : shortcuts[key];
+
     return {
       check,
-      handler: shortcuts[key]
+      handler
     };
   });
 

--- a/packages/slate-keymap/src/index.js
+++ b/packages/slate-keymap/src/index.js
@@ -8,15 +8,16 @@ const Keymap = (shortcuts, options) => {
 
   const functions = Object.keys(shortcuts).map(key => {
     const isKeyPressed = isHotkey(key);
+    const command = shortcuts[key];
 
     const check = (event, editor) => isKeyPressed(event) && config.if(editor);
 
     const handler =
-      typeof shortcuts[key] == "string"
+      typeof command == "string"
         ? (event, editor) => {
-            editor.command(shortcuts[key]);
+            editor.command(command);
           }
-        : shortcuts[key];
+        : command;
 
     return {
       check,


### PR DESCRIPTION
Suggested by @wmertens in #7 

**Example**
```
Keymap({
  "shift+enter": "softBreak"
})
```
Pressing shift enter will call `editor.command("softBreak")`