### PR TITLE
Soft-break on shift+enter

### DIFF
--- a/packages/slate-lists/__tests__/on-shift-enter.js
+++ b/packages/slate-lists/__tests__/on-shift-enter.js
@@ -1,0 +1,40 @@
+/** @jsx h */
+import h from "../../../shared/hyperscript";
+import SlateTest, { createEvent } from "@convertkit/slate-testing-library";
+import Lists from "../src";
+
+describe("onShiftEnter", () => {
+  it("should soft break", () => {
+    const { editor, createValue } = SlateTest({ plugins: Lists() });
+
+    editor.setValue(
+      createValue(
+        <unordered_list>
+          <list_item>
+            <list_item_child>
+              Item 1<cursor />
+            </list_item_child>
+          </list_item>
+        </unordered_list>
+      )
+    );
+
+    const expected = createValue(
+      <unordered_list>
+        <list_item>
+          <list_item_child>
+            {"Item 1\n"}
+            <cursor />
+          </list_item_child>
+        </list_item>
+      </unordered_list>
+    );
+
+    editor.run(
+      "onKeyDown",
+      createEvent.keyDown({ key: "Enter", shiftKey: true })
+    );
+
+    expect(editor.value).toMatchSlateValue(expected);
+  });
+});

--- a/packages/slate-lists/src/create-render-node.js
+++ b/packages/slate-lists/src/create-render-node.js
@@ -25,9 +25,9 @@ export default ({ blocks, classNames }) => (props, editor, next) => {
     }
     case blocks.list_item_child: {
       return (
-        <span className={classNames.list_item_child} {...props.attributes}>
+        <div className={classNames.list_item_child} {...props.attributes}>
           {props.children}
-        </span>
+        </div>
       );
     }
     default:

--- a/packages/slate-lists/src/create-schema.js
+++ b/packages/slate-lists/src/create-schema.js
@@ -23,13 +23,16 @@ export default ({ blocks }) => {
         nodes: [
           {
             match: { type: blocks.list_item_child },
-            min: 1
+            min: 1,
+            max: 1
           },
           {
             match: [
               { type: blocks.unordered_list },
               { type: blocks.ordered_list }
-            ]
+            ],
+            min: 0,
+            max: 1
           }
         ],
         normalize: (editor, error) => {

--- a/packages/slate-lists/src/index.js
+++ b/packages/slate-lists/src/index.js
@@ -89,6 +89,11 @@ export default (options = {}) => {
     );
   };
 
+  const onShiftEnter = (event, editor, next) => {
+    event.preventDefault();
+    editor.insertText("\n");
+  };
+
   const schema = createSchema({ blocks });
   const normalizeNode = createNormalizeNode({ blocks });
   const renderNode = createRenderNode({ blocks, classNames });
@@ -111,6 +116,7 @@ export default (options = {}) => {
       {
         backspace: onBackspace,
         enter: onEnter,
+        "shift+enter": onShiftEnter,
         tab: "increaseListItemDepth",
         "shift+tab": "decreaseListItemDepth"
       },


### PR DESCRIPTION
Closes #16 

Pressing `shift+enter` will now soft break inside a list item child. This allows us to enforce structure and make things a little easier. 