### PR TITLE
fix: increaseItemDepth should move the item into an existing list if it exists

### DIFF
--- a/packages/slate-lists/__tests__/increase-list-item-depth.js
+++ b/packages/slate-lists/__tests__/increase-list-item-depth.js
@@ -82,4 +82,48 @@ describe("increaseListItemDepth", () => {
 
     expect(editor.value).toMatchSlateValue(expected);
   });
+
+  it("should not delete the content", () => {
+    const { editor, createValue } = SlateTest({ plugins: Lists() });
+
+    editor.setValue(
+      createValue(
+        <unordered_list>
+          <list_item>
+            <list_item_child>Test</list_item_child>
+            <unordered_list>
+              <list_item>
+                <list_item_child>Item 1</list_item_child>
+              </list_item>
+            </unordered_list>
+          </list_item>
+          <list_item>
+            <list_item_child>
+              Item 2<cursor />
+            </list_item_child>
+          </list_item>
+        </unordered_list>
+      )
+    );
+
+    const expected = createValue(
+      <unordered_list>
+        <list_item>
+          <list_item_child>Test</list_item_child>
+          <unordered_list>
+            <list_item>
+              <list_item_child>Item 1</list_item_child>
+            </list_item>
+            <list_item>
+              <list_item_child>Item 2</list_item_child>
+            </list_item>
+          </unordered_list>
+        </list_item>
+      </unordered_list>
+    );
+
+    editor.increaseListItemDepth();
+
+    expect(editor.value).toMatchSlateValue(expected);
+  });
 });

--- a/packages/slate-lists/src/commands/increase-list-item-depth.js
+++ b/packages/slate-lists/src/commands/increase-list-item-depth.js
@@ -9,17 +9,31 @@ export default ({ blocks }, editor) => {
   if (!listItem) return;
   if (!previousListItem) return;
 
-  const newList = Block.create({
-    object: "block",
-    type: list.type
-  });
+  // Because of our schema constraints, we know that the second item must be a
+  // list if it exists.
+  const existingList = previousListItem.nodes.get(1);
 
-  editor.withoutNormalizing(() => {
-    editor.insertNodeByKey(
-      previousListItem.key,
-      previousListItem.nodes.size,
-      newList
-    );
-    editor.moveNodeByKey(listItem.key, newList.key, 0);
-  });
+  if (existingList) {
+    editor.withoutNormalizing(() => {
+      editor.moveNodeByKey(
+        listItem.key,
+        existingList.key,
+        existingList.nodes.size
+      );
+    });
+  } else {
+    const newList = Block.create({
+      object: "block",
+      type: list.type
+    });
+
+    editor.withoutNormalizing(() => {
+      editor.insertNodeByKey(
+        previousListItem.key,
+        previousListItem.nodes.size,
+        newList
+      );
+      editor.moveNodeByKey(listItem.key, newList.key, 0);
+    });
+  }
 };


### PR DESCRIPTION
Fixes #22 

Previously, we were just creating a new list and adding it to that. This was a problem if increasing the items depth should have caused it to be inserted into an existing list. 