### PR TITLE
Fix deprecation warning

### DIFF
--- a/packages/slate-lists/src/commands/unwrap-list.js
+++ b/packages/slate-lists/src/commands/unwrap-list.js
@@ -2,7 +2,7 @@ import unwrapListByKey from "./unwrap-list-by-key";
 
 export default ({ blocks }, editor) => {
   const listItemChildren = editor.value.document
-    .getNodesAtRange(editor.value.selection)
+    .getDescendantsAtRange(editor.value.selection)
     .filter(node => node.type == blocks.list_item_child);
 
   const furthestListItems = listItemChildren


### PR DESCRIPTION
As of slate@0.47, the `getNodesAtRange` method has been renamed to `getDescendantsAtRange`.