### PR TITLE
Allow users to set properties on list nodes

### DIFF
--- a/packages/slate-lists/src/commands/toggle-list.js
+++ b/packages/slate-lists/src/commands/toggle-list.js
@@ -11,6 +11,6 @@ export default ({ blocks }, editor, options = {}) => {
   if (sameType) {
     editor.unwrapList();
   } else {
-    editor.setNodeByKey(list.key, type);
+    editor.setNodeByKey(list.key, { ...options.nodeProperties, type });
   }
 };

--- a/packages/slate-lists/src/commands/toggle-list.js
+++ b/packages/slate-lists/src/commands/toggle-list.js
@@ -11,6 +11,9 @@ export default ({ blocks }, editor, options = {}) => {
   if (sameType) {
     editor.unwrapList();
   } else {
-    editor.setNodeByKey(list.key, { ...options.nodeProperties, type });
+    editor.setNodeByKey(
+      list.key,
+      Object.assign({}, options.nodeProperties, { type })
+    );
   }
 };


### PR DESCRIPTION
This will allow users to set custom properties on list nodes. An example of when this could be useful: if you would like to render an `ol` tag with `type="A"` to generate an ordered list using alphabetic characters instead of numbers. Currently, there is no way for a node to remember what type of ordered list it should be. With this change, you could save the type onto the node in `data` and then read that off the node when rendering to decide how you will render the block (assuming you are using a custom renderer).

Basic example of the use case I am trying to accomplish:

```jsx
const toggleBlock = (editor, type) => {
    const { value } = editor;
    const isActive = hasBlock(value, type);

    if (type === UNORDERED_LIST) {
        editor.toggleList();
    } else if (type === ORDERED_ALPHABETIC_LIST) {
        editor.toggleList({ data: { alphabetic: true }, type: ORDERED_LIST });
    } else if (type === ORDERED_LIST) {
        editor.toggleList({ data: { alphabetic: false }, type: ORDERED_LIST });
    } else {
        editor.setBlocks(isActive ? DEFAULT_NODE : type);
    }
};

// Function in my current app that is called when a toolbar button for a block node is pressed
onClickBlock = type => (event) => {
    event.preventDefault();

    toggleBlock(this.editor.current, type);
};

renderBlock = (props, editor, next) => {
    let derivedType = props.node.type;
    if (type === ORDERED_LIST && props.node.data.get('alphabetic') {
        derivedType = ORDERED_ALPHABETIC_LIST;
    }

    switch (derivedType) {
        case UNORDERED_LIST: return <UnorderedListNode {...props} />;
        case IMAGE: return <ImageNode {...props} />;
        case LIST_ITEM: return <ListItemNode {...props} />;
        case LIST_ITEM_CHILD: return <ListItemChildNode {...props} />;
       // Renders: <ol {...this.props.attributes} type={this.props.type}>{this.props.children}</ol>
        case ORDERED_ALPHABETIC_LIST: return <OrderedListNode {...props} type="A" />;
        case ORDERED_LIST: return <OrderedListNode {...props} />;
        case PARAGRAPH: return <ParagraphNode {...props} />;
        default: return next();
    }
};
```