### PR TITLE
fix(blockquotes): Bugfix for wrap blockquote block

### DIFF
--- a/packages/slate-blockquotes/src/create-commands.js
+++ b/packages/slate-blockquotes/src/create-commands.js
@@ -1,10 +1,18 @@
 const wrapWithOptions = (fn, options) => (...args) => fn(options, ...args);
 
 const wrapBlockquote = ({ blocks }, editor, options = {}) => {
-  const block = editor.value.startBlock;
+  const rootBlocks = editor.value.document.getRootBlocksAtRange(
+    editor.value.selection
+  );
   editor.withoutNormalizing(() => {
-    editor.wrapBlockByKey(block.key, blocks.blockquote);
-    editor.wrapBlockByKey(block.key, blocks.blockquote_line);
+    if (rootBlocks.size === 1) {
+      editor.wrapBlockByKey(editor.value.startBlock.key, blocks.blockquote);
+      return;
+    }
+    rootBlocks.forEach(block => {
+      editor.wrapBlockByKey(block.key, blocks.blockquote_line);
+    });
+    editor.wrapBlock(blocks.blockquote);
   });
 };
 

--- a/packages/slate-blockquotes/src/index.js
+++ b/packages/slate-blockquotes/src/index.js
@@ -34,6 +34,18 @@ export default (options = {}) => {
     return next();
   };
 
+  const onBackspace = (event, editor, next) => {
+    const { selection, startBlock } = editor.value;
+    if (selection.isExpanded) return next();
+    if (selection.start.offset !== 0) return next();
+    if (startBlock.getText() !== "") return next();
+    const parent = editor.value.document.getParent(startBlock.key);
+    if (parent.nodes.size > 1) return next();
+    event.preventDefault();
+    editor.delete();
+    editor.unwrapBlockquote();
+  };
+
   const isBlockquoteLine = editor =>
     editor.value.startBlock.type === blocks.blockquote_line;
 
@@ -49,7 +61,8 @@ export default (options = {}) => {
     },
     Keymap(
       {
-        enter: onEnter
+        enter: onEnter,
+        backspace: onBackspace
       },
       { if: isBlockquoteLine }
     )


### PR DESCRIPTION
Change wrap commands to wrap all block nodes in the current selection instead of single block. And add onBackspace handler to remove blank blockquote block.