### PR TITLE
Fix schema normalization in lists

### DIFF
--- a/packages/slate-lists/__tests__/normalizing.js
+++ b/packages/slate-lists/__tests__/normalizing.js
@@ -1,0 +1,105 @@
+/** @jsx h */
+import h from "../../../shared/hyperscript";
+import SlateTest from "@convertkit/slate-testing-library";
+
+import Lists from "../src";
+
+describe("normalizing", () => {
+  describe("child_min_invalid", () => {
+    it("should insert list_item_child", () => {
+      const { editor, createValue, createUnnormalizedValue } = SlateTest({
+        plugins: Lists()
+      });
+
+      editor.setValue(
+        createValue(
+          <unordered_list>
+            <list_item>
+              <unordered_list>
+                <list_item>
+                  <list_item_child>
+                    <text />
+                  </list_item_child>
+                </list_item>
+              </unordered_list>
+            </list_item>
+          </unordered_list>
+        )
+      );
+
+      const expected = createUnnormalizedValue(
+        <unordered_list>
+          <list_item>
+            <list_item_child>
+              <text />
+            </list_item_child>
+            <unordered_list>
+              <list_item>
+                <list_item_child>
+                  <text />
+                </list_item_child>
+              </list_item>
+            </unordered_list>
+          </list_item>
+        </unordered_list>
+      );
+      expect(editor.value).toMatchSlateValue(expected);
+    });
+  });
+
+  describe("child_invalid_type", () => {
+    it("should wrap with list_item_child", () => {
+      const { editor, createValue, createUnnormalizedValue } = SlateTest({
+        plugins: Lists()
+      });
+
+      editor.setValue(
+        createValue(
+          <unordered_list>
+            <list_item />
+          </unordered_list>
+        )
+      );
+
+      const expected = createUnnormalizedValue(
+        <unordered_list>
+          <list_item>
+            <list_item_child>
+              <text />
+            </list_item_child>
+          </list_item>
+        </unordered_list>
+      );
+      expect(editor.value).toMatchSlateValue(expected);
+    });
+  });
+
+  describe("parent_invalid_type", () => {
+    it("should wrap with unordered_list", () => {
+      const { editor, createValue, createUnnormalizedValue } = SlateTest({
+        plugins: Lists()
+      });
+
+      editor.setValue(
+        createValue(
+          <list_item>
+            <list_item_child>
+              <text />
+            </list_item_child>
+          </list_item>
+        )
+      );
+
+      const expected = createUnnormalizedValue(
+        <unordered_list>
+          <list_item>
+            <list_item_child>
+              <text />
+            </list_item_child>
+          </list_item>
+        </unordered_list>
+      );
+      expect(editor.value).toMatchSlateValue(expected);
+    });
+  });
+});

--- a/packages/slate-lists/src/create-schema.js
+++ b/packages/slate-lists/src/create-schema.js
@@ -55,7 +55,7 @@ export default ({ blocks }) => {
               });
               return;
             case "parent_type_invalid":
-              editor.wrapBlock(blocks.unordered_list);
+              editor.wrapBlockByKey(error.node.key, blocks.unordered_list);
               return;
             default:
               return;

--- a/packages/slate-lists/src/create-schema.js
+++ b/packages/slate-lists/src/create-schema.js
@@ -1,3 +1,5 @@
+import { Block, Text } from "slate";
+
 export default ({ blocks }) => {
   return {
     blocks: {
@@ -38,10 +40,16 @@ export default ({ blocks }) => {
         normalize: (editor, error) => {
           switch (error.code) {
             case "child_min_invalid":
-              editor.insertNodeByKey(error.node.key, 0, {
-                object: "block",
-                type: blocks.list_item_child
-              });
+              editor.insertNodeByKey(
+                error.node.key,
+                0,
+                Block.create({
+                  object: "block",
+                  type: blocks.list_item_child,
+                  nodes: [Text.create()]
+                })
+              );
+              return;
             case "child_type_invalid":
               editor.wrapBlockByKey(error.child.key, {
                 type: blocks.list_item_child

--- a/packages/slate-lists/src/create-schema.js
+++ b/packages/slate-lists/src/create-schema.js
@@ -44,7 +44,6 @@ export default ({ blocks }) => {
                 error.node.key,
                 0,
                 Block.create({
-                  object: "block",
                   type: blocks.list_item_child,
                   nodes: [Text.create()]
                 })

--- a/packages/slate-testing-library/src/index.js
+++ b/packages/slate-testing-library/src/index.js
@@ -23,9 +23,23 @@ const SlateTest = options => {
     return editor.value;
   };
 
+  const createUnnormalizedValue = children => {
+    const editor = new Editor({
+      normalize: false
+    });
+    const value = html`
+      <value>
+        <document>${children}</document>
+      </value>
+    `;
+
+    editor.setValue(value);
+    return editor.value;
+  };
+
   const editor = new Editor(options);
 
-  return { editor, createValue };
+  return { editor, createValue, createUnnormalizedValue };
 };
 
 const print = value => hyperprint(value, { strict: true });


### PR DESCRIPTION
This intends to fix the bugs reported in issues #31 and #34.

Slate's `insertNodeByKey` expects a `Node`, not a `properties` object (https://docs.slatejs.org/slate-core/commands#insertnodebykey-path) This is why Slate was throwing the `Cannot read property 'key' of undefined` exception.

Furthermore, as each `blocks.list_item` needs at least a `list_item_child` (which is a leaf with text), I introduce an empty text as its single `Node`, when `blocks.list_item` needs to be created in the `normalize` function.

Finally, I do not see any point in calling `wrapBlock` in the `normalize` function (it wraps the _selected_ blocks). I changed it for `wrapBlockByKey`.

The new behavior on pasting is:

![Peek 2019-10-15 14-55](https://user-images.githubusercontent.com/17606011/66833291-dc624180-ef5b-11e9-8575-49513bfb6a72.gif)


