### PR TITLE
Blockquotes: Improve normalization function and add tests

### DIFF
--- a/packages/slate-blockquotes/__tests__/normalizing.js
+++ b/packages/slate-blockquotes/__tests__/normalizing.js
@@ -6,7 +6,7 @@ import Blockquotes from "../src";
 
 describe("blockquote", () => {
   describe("child_type_invalid", () => {
-    it("should insert list_item_child", () => {
+    it("should wrap with blockquote_line", () => {
       const { editor, createValue, createUnnormalizedValue } = SlateTest({
         plugins: Blockquotes()
       });

--- a/packages/slate-blockquotes/__tests__/normalizing.js
+++ b/packages/slate-blockquotes/__tests__/normalizing.js
@@ -1,0 +1,55 @@
+/** @jsx h */
+import h from "../../../shared/hyperscript";
+import SlateTest from "@convertkit/slate-testing-library";
+
+import Blockquotes from "../src";
+
+describe("blockquote", () => {
+  describe("child_type_invalid", () => {
+    it("should insert list_item_child", () => {
+      const { editor, createValue, createUnnormalizedValue } = SlateTest({
+        plugins: Blockquotes()
+      });
+
+      editor.setValue(createValue(<blockquote />));
+
+      const expected = createUnnormalizedValue(
+        <blockquote>
+          <blockquote_line />
+        </blockquote>
+      );
+      expect(editor.value).toMatchSlateValue(expected);
+    });
+  });
+});
+
+describe("blockquote-line", () => {
+  describe("child_type_invalid", () => {
+    it("should remove invalid child node and append its children", () => {
+      const { editor, createValue, createUnnormalizedValue } = SlateTest({
+        plugins: Blockquotes()
+      });
+
+      editor.setValue(
+        createValue(
+          <blockquote>
+            <blockquote_line>
+              <unordered_list>
+                Text 1<link>Text 2</link>
+              </unordered_list>
+            </blockquote_line>
+          </blockquote>
+        )
+      );
+
+      const expected = createUnnormalizedValue(
+        <blockquote>
+          <blockquote_line>
+            Text 1<link>Text 2</link>
+          </blockquote_line>
+        </blockquote>
+      );
+      expect(editor.value).toMatchSlateValue(expected);
+    });
+  });
+});

--- a/packages/slate-blockquotes/__tests__/normalizing.js
+++ b/packages/slate-blockquotes/__tests__/normalizing.js
@@ -6,7 +6,7 @@ import Blockquotes from "../src";
 
 describe("blockquote", () => {
   describe("child_type_invalid", () => {
-    it("should wrap with blockquote_line", () => {
+    it("should wrap child with blockquote_line", () => {
       const { editor, createValue, createUnnormalizedValue } = SlateTest({
         plugins: Blockquotes()
       });
@@ -24,6 +24,23 @@ describe("blockquote", () => {
 });
 
 describe("blockquote-line", () => {
+  describe("parent_type_invalid", () => {
+    it("should wrap blockquote_line with blockquote block", () => {
+      const { editor, createValue, createUnnormalizedValue } = SlateTest({
+        plugins: Blockquotes()
+      });
+
+      editor.setValue(createValue(<blockquote_line />));
+
+      const expected = createUnnormalizedValue(
+        <blockquote>
+          <blockquote_line />
+        </blockquote>
+      );
+      expect(editor.value).toMatchSlateValue(expected);
+    });
+  });
+
   describe("child_type_invalid", () => {
     it("should remove invalid child node and append its children", () => {
       const { editor, createValue, createUnnormalizedValue } = SlateTest({

--- a/packages/slate-blockquotes/src/create-schema.js
+++ b/packages/slate-blockquotes/src/create-schema.js
@@ -35,6 +35,9 @@ export default ({ blocks }) => {
         ],
         normalize: (editor, error) => {
           switch (error.code) {
+            case "parent_type_invalid":
+              editor.wrapBlockByKey(error.node.key, blocks.blockquote);
+              return;
             case "child_object_invalid":
               error.child.nodes.forEach((node, index) => {
                 editor.moveNodeByKey(node.key, error.node.key, index);

--- a/packages/slate-blockquotes/src/create-schema.js
+++ b/packages/slate-blockquotes/src/create-schema.js
@@ -15,13 +15,11 @@ export default ({ blocks }) => {
                 object: "block",
                 type: blocks.blockquote_line
               });
+              return;
             case "child_type_invalid":
               editor.wrapBlockByKey(error.child.key, {
                 type: blocks.blockquote_line
               });
-              return;
-            case "parent_type_invalid":
-              editor.wrapBlock(blocks.blockquote);
               return;
             default:
               return;

--- a/shared/hyperscript/index.js
+++ b/shared/hyperscript/index.js
@@ -8,8 +8,12 @@ export default createHyperscript({
     list_item_child: "list-item-child",
     ordered_list: "ordered-list",
     paragraph: "paragraph",
-    unordered_list: "unordered-list"
+    unordered_list: "unordered-list",
+    blockquote: "blockquote",
+    blockquote_line: "blockquote-line"
   },
-  inlines: {},
+  inlines: {
+    link: "link"
+  },
   marks: {}
 });


### PR DESCRIPTION
This intends to improve the normalize rules for the schema of `slate-blockquotes`.

* In the case of 'child_min_invalid' in `blockquotes`, a 'return' statement was missing.
* There is no point in having the case `parent_type_invalid` in `blockquotes`, but it makes perfect sense in `blockquote-line`.

Test cases have been added :rocket: 
