### PR TITLE
Update package.json to include the repository key

### DIFF
--- a/packages/slate-htm/package.json
+++ b/packages/slate-htm/package.json
@@ -9,6 +9,11 @@
     "lint": "eslint . --max-warnings=0",
     "build": "library build"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ConvertKit/slate-plugins.git",
+    "directory": "packages/slate-htm"
+  },
   "author": "",
   "license": "MIT",
   "peerDependencies": {

--- a/packages/slate-keymap/package.json
+++ b/packages/slate-keymap/package.json
@@ -9,6 +9,11 @@
     "lint": "eslint . --max-warnings=0",
     "build": "library build"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ConvertKit/slate-plugins.git",
+    "directory": "packages/slate-keymap"
+  },
   "author": "",
   "license": "MIT",
   "peerDependencies": {

--- a/packages/slate-testing-library/package.json
+++ b/packages/slate-testing-library/package.json
@@ -9,6 +9,11 @@
     "lint": "eslint . --max-warnings=0",
     "build": "library build"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ConvertKit/slate-plugins.git",
+    "directory": "packages/slate-testing-library"
+  },
   "author": "",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
	*@convertkit/slate-keymap